### PR TITLE
Fix iOS16 not rendering icons

### DIFF
--- a/Sources/AnimatedTabBar/AnimatedTabbar.swift
+++ b/Sources/AnimatedTabBar/AnimatedTabbar.swift
@@ -88,6 +88,10 @@ public struct AnimatedTabBar: View {
                             view.animation(.linear) {
                                 $0.foregroundStyle(selectedIndex == i ? selectedColor : unselectedColor)
                             }
+                        } else {
+                            view
+                            .foregroundStyle(selectedIndex == i ? selectedColor : unselectedColor)
+                            .animation(buttonsAnimation, value: selectedIndex)
                         }
 #else
                         view


### PR DESCRIPTION
Closes #7

This fixes the issue where on iOS16 icons don't appear. It looks like the fallback logic for the iOS17 check was missed to fallback to the view that works with iOS16. I'm unsure we need the Swift check now, but that should probably be a seperate PR.