### PR TITLE
Add `Image` size option to WiggleButton

### DIFF
--- a/Sources/AnimatedTabBar/TabBarButtons/WiggleButton.swift
+++ b/Sources/AnimatedTabBar/TabBarButtons/WiggleButton.swift
@@ -11,11 +11,13 @@ public struct WiggleButton: View {
 
     public var image: Image
     public var maskImage: Image
+    public var imageSize: CGFloat
     public var isSelected: Bool
 
-    public init(image: Image, maskImage: Image, isSelected: Bool) {
+    public init(image: Image, maskImage: Image, imageSize: CGFloat? = nil, isSelected: Bool) {
         self.image = image
         self.maskImage = maskImage
+        self.imageSize = imageSize ?? 20
         self.isSelected = isSelected
     }
 
@@ -30,8 +32,12 @@ public struct WiggleButton: View {
         ZStack {
             WiggleButtonBg(t: tForBg)
                 .opacity(0.4)
-                .mask(maskImage)
+                .mask(
+                    maskImage
+                        .imageResizer(imageSize)
+                )
             image
+                .imageResizer(imageSize)
         }
         .scaleEffect(scale)
         .onChange(of: isSelected) { newValue in
@@ -80,4 +86,3 @@ struct WiggleButtonBg: Shape {
         return path
     }
 }
-

--- a/Sources/AnimatedTabBar/Utils.swift
+++ b/Sources/AnimatedTabBar/Utils.swift
@@ -66,3 +66,12 @@ extension View {
         modifier(FrameGetter(frame: frame))
     }
 }
+
+extension Image {
+    func imageResizer(_ size: CGFloat) -> some View {
+        self
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .frame(width: size, height: size)
+   }
+}


### PR DESCRIPTION
If you use a custom image for `WiggleButton` or even other ones, they may be not the desired size for a TabBar, so you need to resize it.
This PR adds this optional option to `WiggleButton` with a default value of `20` for frame's width and height.